### PR TITLE
Export required env variable for commit signing

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -1,0 +1,5 @@
+# Signing GitHub commits 
+# https://docs.github.com/en/github/authenticating-to-github/managing-commit-signature-verification
+# https://www.gnupg.org/documentation/manuals/gnupg/Invoking-GPG_002dAGENT.html
+export GPG_TTY=$(tty)
+


### PR DESCRIPTION
Commit signing[1]
Info on why the GPG_TTY variable needs to be exported[2]

[1] https://docs.github.com/en/github/authenticating-to-github/managing-commit-signature-verification
[2] https://www.gnupg.org/documentation/manuals/gnupg/Invoking-GPG_002dAGENT.html